### PR TITLE
test: use Cargo-provided binary

### DIFF
--- a/tests/init_integration_test.rs
+++ b/tests/init_integration_test.rs
@@ -4,21 +4,7 @@ use tempfile::TempDir;
 
 /// Get the path to the compiled uncomment binary
 fn get_binary_path() -> std::path::PathBuf {
-    let build_output = Command::new("cargo")
-        .args(["build", "--bin", "uncomment"])
-        .output()
-        .expect("Failed to build binary");
-
-    if !build_output.status.success() {
-        panic!(
-            "Failed to build binary: {}",
-            String::from_utf8_lossy(&build_output.stderr)
-        );
-    }
-
-    let mut binary_path = std::env::current_dir().expect("Failed to get current directory");
-    binary_path.push("target/debug/uncomment");
-    binary_path
+    std::path::PathBuf::from(env!("CARGO_BIN_EXE_uncomment"))
 }
 
 /// Comprehensive integration test for the init command


### PR DESCRIPTION
## Summary

Use the Cargo-provided `CARGO_BIN_EXE_uncomment` variable to locate the binary in integration tests.

## Motivation

Cargo already builds binary targets for integration tests and provides their paths through `CARGO_BIN_EXE_<name>`. The current helper starts a nested `cargo build` and assumes the binary is at `target/debug/uncomment`.

Using the provided path avoids the redundant build, respects the selected profile and target platform, and lets sandboxed downstream builds run these tests without patching or skipping them.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- --deny warnings`
- `cargo test`
- `cargo test --all-features`